### PR TITLE
Correctly process list input in PointData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix missing type declarations in DDS for installation module outputs
+- Fixed PointData incorrectly storing coordinates passed as lists.
 
 ## [1.0.1] - 2017-03-09
 
 ### Changed
 
-- Upgraded dtocean-electrical to version 1.0.1
+- Upgraded dtocean-core to version 1.0.1
 
 ## [1.0.0] - 2017-02-23
 

--- a/dtocean_core/data/definitions.py
+++ b/dtocean_core/data/definitions.py
@@ -2444,10 +2444,6 @@ class PointData(Structure):
             
             point = raw
             
-        elif isinstance(raw, list):
-            
-            point = raw[0]
-            
         else:
             
             point = Point(*[float(x) for x in raw])


### PR DESCRIPTION
For some reason lists given to PointData were just storing the first entry (maybe expecting lists of points?).
This behaviour was removed.

Fixes DTOcean/dtocean-issues#18