### PR TITLE
Move the optimizer status codes back to a three value system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.2] - 2022-04-25
+
+### Changed
+
+-   The `AdvancedPosition.get_optimiser_status` method now returns a code in
+    the range `[0, 2]`, with `0` meaning the status can not be determined, `1` 
+    meaning the optimisation is complete and `2` meaning the optimisation is 
+    incomplete.
+
+## [3.0.1] - 2022-04-14
+
+### Changed
+
+-   The minimum version of the aneris dependency was set to 0.11.1 or greater.
+
 ## [3.0.0] - 2022-04-04
 
 ### Added

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@
 #---------------------------------#
 
 # version format
-version: 3.0.1.build{build}
+version: 3.0.2.build{build}
 
 environment:
   matrix:

--- a/dtocean_core/strategies/position.py
+++ b/dtocean_core/strategies/position.py
@@ -295,7 +295,7 @@ class AdvancedPosition(Strategy):
         _, work_dir_status = self.get_worker_directory_status(config_copy)
         _, optim_status = self.get_optimiser_status(core, config_copy)
         
-        if work_dir_status == 0 and optim_status == 1:
+        if work_dir_status == 0 and optim_status == 2:
             
             log_str = 'Attempting restart of incomplete strategy'
             module_logger.info(log_str)
@@ -582,7 +582,7 @@ class AdvancedPosition(Strategy):
                                                                         core,
                                                                         config)
         
-        if optimiser_status_code == 0: return False
+        if optimiser_status_code == 1: return False
         
         return True
     
@@ -632,7 +632,7 @@ class AdvancedPosition(Strategy):
         if os.path.isfile(results_path):
             
             status_str = "Optimisation complete"
-            status_code = 0
+            status_code = 1
             
             return status_str, status_code
         
@@ -643,7 +643,7 @@ class AdvancedPosition(Strategy):
             
             status_str = ("Optimisation incomplete (restart may be "
                           "possible)")
-            status_code = 1
+            status_code = 2
         
         return status_str, status_code
     

--- a/tests/test_strategies_position.py
+++ b/tests/test_strategies_position.py
@@ -175,7 +175,7 @@ def test_advanced_get_optimiser_status_complete(tmpdir):
     (status_str,
      status_code) = AdvancedPosition.get_optimiser_status(None, config)
     
-    assert status_code == 0
+    assert status_code == 1
     assert "complete" in status_str
 
 
@@ -191,7 +191,7 @@ def test_advanced_get_optimiser_status_incomplete(mocker, tmpdir):
     (status_str,
      status_code) = AdvancedPosition.get_optimiser_status(None, config)
     
-    assert status_code == 1
+    assert status_code == 2
     assert "incomplete" in status_str
 
 
@@ -437,7 +437,7 @@ def test_advanced_pre_execute_restart(caplog, mocker, advanced):
     
     mocker.patch.object(advanced,
                         "get_optimiser_status",
-                        return_value=["mock", 1],
+                        return_value=["mock", 2],
                         autospec=True)
     
     advanced._config = {'clean_existing_dir': "mock",
@@ -467,7 +467,7 @@ def test_advanced_pre_execute_start(mocker, advanced):
     
     mocker.patch.object(advanced,
                         "get_optimiser_status",
-                        return_value=["mock", 0],
+                        return_value=["mock", 1],
                         autospec=True)
     
     mocker.patch.object(advanced,
@@ -1487,8 +1487,8 @@ def test_advanced_export_config_template(mocker, advanced):
                          (0,      None,   None,   None,   None,   False),
                          (1,      0,      None,   None,   None,   False),
                          (1,      1,      None,   None,   None,   False),
-                         (1,      1,      "mock", 0,      0,      False),
-                         (1,      1,      "mock", 0,      1,      True),
+                         (1,      1,      "mock", 0,      1,      False),
+                         (1,      1,      "mock", 0,      2,      True),
                          (1,      1,      "mock", 1,      None,   True)])
 def test_advanced_allow_run(mocker,
                             p_code,


### PR DESCRIPTION
This is for consistent numbering (i.e. 1 is good, 2 is medium) and for integration with the GUI which needs to see that 0 is bad.

Bump version to 3.0.2